### PR TITLE
Versions in separate config map to avoid unecessary pod restarts

### DIFF
--- a/dev/bases/veidemann/dashboard_patch.yaml
+++ b/dev/bases/veidemann/dashboard_patch.yaml
@@ -8,7 +8,7 @@ spec:
       volumes:
         - name: versions
           configMap:
-            name: veidemann
+            name: veidemann-version
             items:
               - key: versions.json
                 path: versions.json

--- a/dev/bases/veidemann/health-check_env_patch.yaml
+++ b/dev/bases/veidemann/health-check_env_patch.yaml
@@ -8,7 +8,7 @@ spec:
       volumes:
         - name: versions
           configMap:
-            name: veidemann
+            name: veidemann-version
             items:
               - key: versions.json
                 path: versions.json

--- a/dev/bases/veidemann/kustomization.yaml
+++ b/dev/bases/veidemann/kustomization.yaml
@@ -73,6 +73,9 @@ configMapGenerator:
       - log4j2.xml
     literals:
       - openidConnectIssuer=https://veidemann.local/dex
+  - name: veidemann-version
+    literals:
+      - versions.json={"veidemann":"dev"}
   - name: veidemann-dashboard-environment
     behavior: replace
     files:

--- a/dev/kind/deploy_veidemann.sh
+++ b/dev/kind/deploy_veidemann.sh
@@ -13,11 +13,13 @@ SCRIPT_DIR=$(dirname $0)
 # Basic safeguard to ensure that we're working in a development-context
 if ! [[ $(kubectl config current-context) = *kind* ]]; then echo "WARNING: Not a dev context, use: kubectl config use-context kind-kind ";  exit 1; fi
 
-# Set version and apply
-cat << EOF > versions.json
-{"veidemann": "$(git describe --tag --always --dirty)"}
-EOF
+VERSIONS=$(kustomize build $SCRIPT_DIR | ${SCRIPT_DIR}/../../scripts/versions.sh)
+
+# backup
+mv versions.json versions.json.tmp
+echo $VERSIONS > versions.json
 
 kustomize build $SCRIPT_DIR | kubectl apply -f -
 
-rm versions.json
+# restore
+mv versions.json.tmp versions.json

--- a/dev/kind/versions.json
+++ b/dev/kind/versions.json
@@ -1,0 +1,1 @@
+{"veidemann":  "kind"}

--- a/dev/minikube/deploy_veidemann.sh
+++ b/dev/minikube/deploy_veidemann.sh
@@ -14,11 +14,13 @@ SCRIPT_DIR=$(dirname $0)
 # Basic safeguard to ensure that we're working in a development-context
 if ! [[ $(kubectl config current-context) = *minikube* ]]; then echo "WARNING: Not a dev context, use: kubectl config use-context minikube";  exit 1; fi
 
-# Set version and apply
-cat << EOF > versions.json
-{"veidemann": "$(git describe --tag --always --dirty)"}
-EOF
+VERSIONS=$(kustomize build $SCRIPT_DIR | ${SCRIPT_DIR}/../../scripts/versions.sh)
+
+# backup
+mv versions.json versions.json.tmp
+echo $VERSIONS > versions.json
 
 kustomize build $SCRIPT_DIR | kubectl apply -f -
 
-rm versions.json
+# restore
+mv versions.json.tmp versions.json

--- a/dev/minikube/kustomization.yaml
+++ b/dev/minikube/kustomization.yaml
@@ -20,7 +20,7 @@ patchesJson6902:
           value: "false"
 
 configMapGenerator:
-  - name: veidemann
-    behavior: merge
+  - name: veidemann-version
+    behavior: replace
     files:
       - versions.json

--- a/dev/minikube/versions.json
+++ b/dev/minikube/versions.json
@@ -1,0 +1,1 @@
+{"veidemann":  "minikube"}

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Pipe kubernetes manifests into this script and get a JSON object
+# with image name and version as output
+#
+# Example usage:
+# kustomize build | ./versions.sh | jq
+
+# overall version
+tag=$(git describe --tag --always --dirty)
+
+# read standard input into variable
+input=$(</dev/stdin)
+
+# grep for images in kubernetes yaml syntax
+images=$(echo "$input" | grep -e '^[[:blank:]]*image: [^ ]*' | awk '{print $2}')
+
+# count number of images to be able to not append last comma in json output
+count=$(echo "$images" | wc -l)
+
+# start json object
+VERSIONS_JSON+="{"
+
+# append overall version
+VERSIONS_JSON+="\"veidemann\": \"$tag\","
+
+# append image versions
+for version in $images; do
+  ((count--))
+  # split single version into parts delimited by colon
+  IFS=':' read -a parts <<<${version}
+  # append image version
+  VERSIONS_JSON+="\"${parts[0]}\": \"${parts[1]}\""
+  if ((count > 0)); then VERSIONS_JSON+=","; fi
+done
+
+# end json object
+VERSIONS_JSON+="}"
+
+# output images as json object
+echo "$VERSIONS_JSON"


### PR DESCRIPTION
Create versions.json files that is altered before deploy and reset after to avoid dirty git repository.

Include versions of all deployed images.