### PR TITLE
Update util pod to use norsknettarkiv/veidemann-warc-inspector-image container image

### DIFF
--- a/dev/bases/veidemann-util-pod.yaml
+++ b/dev/bases/veidemann-util-pod.yaml
@@ -22,7 +22,7 @@ spec:
         claimName: veidemann-backup
   containers:
     - name: busybox
-      image: busybox
+      image: norsknettarkiv/veidemann-warc-inspector-image:1.1.0
       args:
         - "sh"
         - "-c"


### PR DESCRIPTION
The veidemann-warc-inspector-image contains tools to work with warc files:
- warctools
- gowarc
- jhove-warc-report-parser
- jq