### PR TITLE
veidemann-dashboard: make environment.json valid out-of-the-box

### DIFF
--- a/bases/veidemann-dashboard/kustomization.yaml
+++ b/bases/veidemann-dashboard/kustomization.yaml
@@ -11,4 +11,4 @@ commonLabels:
 configMapGenerator:
   - name: veidemann-dashboard-environment
     literals:
-      - environment.json=""
+      - environment.json="{}"


### PR DESCRIPTION
To be able to easily skaffold the bases kustomization.