### PR TITLE
Remove NODE_NAME environment variables

### DIFF
--- a/bases/rethinkdb-backup/cronjob.yaml
+++ b/bases/rethinkdb-backup/cronjob.yaml
@@ -35,10 +35,6 @@ spec:
             - name: rethinkdb-backup
               image: norsknettarkiv/rethinkdb-backup:0.3.1
               env:
-                - name: NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.hostIP
                 - name: DB_HOST
                   value: "rethinkdb-proxy"
                 - name: DB_PORT

--- a/bases/rethinkdb-exporter/deployment.yaml
+++ b/bases/rethinkdb-exporter/deployment.yaml
@@ -37,10 +37,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: DB_HOST
               value: "rethinkdb-proxy"
             - name: DB_PORT

--- a/bases/veidemann-contentwriter/deployment.yaml
+++ b/bases/veidemann-contentwriter/deployment.yaml
@@ -53,10 +53,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: DB_HOST
               value: "rethinkdb-proxy"
             - name: DB_PORT

--- a/bases/veidemann-controller/deployment.yaml
+++ b/bases/veidemann-controller/deployment.yaml
@@ -51,10 +51,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: API_PORT
               value: "7700"
             - name: DB_HOST

--- a/bases/veidemann-db-initializer/job.yaml
+++ b/bases/veidemann-db-initializer/job.yaml
@@ -24,10 +24,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: DB_HOST
               value: "rethinkdb-proxy"
             - name: DB_PORT

--- a/bases/veidemann-dns-resolver/deployment.yaml
+++ b/bases/veidemann-dns-resolver/deployment.yaml
@@ -28,10 +28,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: DB_HOST
               value: "rethinkdb-proxy"
             - name: DB_PORT

--- a/bases/veidemann-frontier/deployment.yaml
+++ b/bases/veidemann-frontier/deployment.yaml
@@ -58,11 +58,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.hostIP
             - name: DB_HOST
               value: "rethinkdb-proxy"
             - name: DB_PORT

--- a/bases/veidemann-harvester/deployment.yaml
+++ b/bases/veidemann-harvester/deployment.yaml
@@ -55,11 +55,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.hostIP
             - name: PORT
               value: "9999"
             - name: DB_HOST

--- a/bases/veidemann-metrics/deployment.yaml
+++ b/bases/veidemann-metrics/deployment.yaml
@@ -34,10 +34,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: DB_HOST
               value: "rethinkdb-cluster"
             - name: DB_PORT

--- a/bases/veidemann-robotsevaluator/deployment.yaml
+++ b/bases/veidemann-robotsevaluator/deployment.yaml
@@ -44,11 +44,6 @@ spec:
                 name: veidemann-rethinkdb-env
                 optional: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.hostIP
             - name: DB_HOST
               value: "rethinkdb-proxy"
             - name: DB_PORT


### PR DESCRIPTION
NODE_NAME is not directly used in the repo. Kustomize currently
prepends overlayed environment variables by default and thus
the usecase for NODE_NAME is no longer there since it must be
defined before using it.