### PR TITLE
dev: Remove deleted patch from dev kustomization

### DIFF
--- a/dev/bases/veidemann/kustomization.yaml
+++ b/dev/bases/veidemann/kustomization.yaml
@@ -45,7 +45,6 @@ patchesStrategicMerge:
   - rethinkdb_backup_env_patch.yaml
   - rethinkdb_backup_volume_patch.yaml
   - robotsevaluator_env_patch.yaml
-  - warcvalidator_env_patch.yaml
   - warcvalidator_volume_patch.yaml
   - harvester_log_level_patch.yaml
   - dashboard_patch.yaml


### PR DESCRIPTION
Without this fix it is not possible to build the dev kustomization for kind/minikube.