### PR TITLE
Downgrade veidemann-contentwriter to version 0.3.1

### DIFF
--- a/bases/veidemann-contentwriter/deployment.yaml
+++ b/bases/veidemann-contentwriter/deployment.yaml
@@ -36,7 +36,7 @@ spec:
                 path: log4j2.xml
       containers:
         - name: veidemann-contentwriter
-          image: norsknettarkiv/veidemann-contentwriter:0.4.0
+          image: norsknettarkiv/veidemann-contentwriter:0.3.1
           ports:
             - name: grpc
               containerPort: 8082


### PR DESCRIPTION
Premature removal of storage_ref writing. It is used by check if
content is crawled.