### PR TITLE
Fix bug in rethinkdbadapter

### DIFF
--- a/bases/veidemann-controller/deployment.yaml
+++ b/bases/veidemann-controller/deployment.yaml
@@ -40,7 +40,7 @@ spec:
 
       containers:
         - name: veidemann-controller
-          image: norsknettarkiv/veidemann-controller:0.6.2
+          image: norsknettarkiv/veidemann-controller:0.6.3
           imagePullPolicy: IfNotPresent
           ports:
             - name: grpc

--- a/bases/veidemann-frontier/deployment.yaml
+++ b/bases/veidemann-frontier/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 
       containers:
         - name: veidemann-frontier
-          image: norsknettarkiv/veidemann-frontier:0.6.1
+          image: norsknettarkiv/veidemann-frontier:0.6.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 7700

--- a/bases/veidemann-harvester/deployment.yaml
+++ b/bases/veidemann-harvester/deployment.yaml
@@ -110,7 +110,7 @@ spec:
               name: cache-certificate
               readOnly: true
         - name: veidemann-harvester-proxy
-          image: norsknettarkiv/veidemann-recorderproxy:v0.2.6
+          image: norsknettarkiv/veidemann-recorderproxy:v0.2.8
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9900

--- a/bases/veidemann-harvester/deployment.yaml
+++ b/bases/veidemann-harvester/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: veidemann-browser-controller
-          image: norsknettarkiv/veidemann-browser-controller:v0.1.3
+          image: norsknettarkiv/veidemann-browser-controller:v0.1.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9999


### PR DESCRIPTION
A set of updates to fix rethinkdbadapter bug as well as updating to latest version of veidemann-api for veidemann-recorderproxy and veidemann-browser-controller.