### PR TITLE
Update veidemann-controller to version 0.6.4

### DIFF
--- a/bases/veidemann-controller/deployment.yaml
+++ b/bases/veidemann-controller/deployment.yaml
@@ -40,7 +40,7 @@ spec:
 
       containers:
         - name: veidemann-controller
-          image: norsknettarkiv/veidemann-controller:0.6.3
+          image: norsknettarkiv/veidemann-controller:0.6.4
           imagePullPolicy: IfNotPresent
           ports:
             - name: grpc


### PR DESCRIPTION
Changes label key used to specify type of frontier