### PR TITLE
Update veidemann-db-initializer to version 0.5.6

### DIFF
--- a/bases/veidemann-db-initializer/job.yaml
+++ b/bases/veidemann-db-initializer/job.yaml
@@ -17,7 +17,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: veidemann-db-initializer
-          image: norsknettarkiv/veidemann-db-initializer:0.5.3
+          image: norsknettarkiv/veidemann-db-initializer:0.5.6
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
Extract outlink script now filters out useless links