### PR TITLE
Update veidemann-dashboard to version v0.15.2

### DIFF
--- a/bases/veidemann-dashboard/deployment.yaml
+++ b/bases/veidemann-dashboard/deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
       containers:
         - name: veidemann-dashboard
-          image: norsknettarkiv/veidemann-dashboard:v0.15.1
+          image: norsknettarkiv/veidemann-dashboard:v0.15.2
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
Fixes multiupdate of seeds inadvertently enabling all.