### PR TITLE
Update veideman-frontier to version 0.6.5

### DIFF
--- a/bases/veidemann-frontier/deployment.yaml
+++ b/bases/veidemann-frontier/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 
       containers:
         - name: veidemann-frontier
-          image: norsknettarkiv/veidemann-frontier:0.6.4
+          image: norsknettarkiv/veidemann-frontier:0.6.5
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 7700


### PR DESCRIPTION
Fixes thread starvation when communicating with redis.