### PR TITLE
Update veidemann-frontier to version 0.6.7

### DIFF
--- a/bases/veidemann-frontier/deployment.yaml
+++ b/bases/veidemann-frontier/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 
       containers:
         - name: veidemann-frontier
-          image: norsknettarkiv/veidemann-frontier:0.6.6
+          image: norsknettarkiv/veidemann-frontier:0.6.7
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 7700


### PR DESCRIPTION
A lot less db load and live aggregation of job executions.