### PR TITLE
Fix WARC newline after HTTP request and HTTP response header

### DIFF
--- a/bases/veidemann-contentwriter/deployment.yaml
+++ b/bases/veidemann-contentwriter/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           emptyDir: {}
       containers:
         - name: veidemann-contentwriter
-          image: ghcr.io/nlnwa/veidemann-contentwriter:1.0.0-alpha.9
+          image: ghcr.io/nlnwa/veidemann-contentwriter:1.0.0-alpha.10
           ports:
             - name: grpc
               containerPort: 8082

--- a/bases/veidemann-dashboard/deployment.yaml
+++ b/bases/veidemann-dashboard/deployment.yaml
@@ -28,7 +28,7 @@ spec:
                 path: config.json
       containers:
         - name: veidemann-dashboard
-          image: ghcr.io/nlnwa/veidemann-dashboard:0.18.8
+          image: ghcr.io/nlnwa/veidemann-dashboard:0.19.0
           ports:
             - containerPort: 80
               name: http

--- a/bases/veidemann-harvester/deployment.yaml
+++ b/bases/veidemann-harvester/deployment.yaml
@@ -102,7 +102,7 @@ spec:
               name: cache-certificate
               readOnly: true
         - name: veidemann-harvester-proxy
-          image: norsknettarkiv/veidemann-recorderproxy:v0.3.0
+          image: ghcr.io/nlnwa/veidemann-recorderproxy:0.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9900

--- a/dev/veidemann/util-pod/veidemann-util-pod.yaml
+++ b/dev/veidemann/util-pod/veidemann-util-pod.yaml
@@ -13,7 +13,7 @@ spec:
         claimName: veidemann-backup
   containers:
     - name: warc-inspector-image
-      image: norsknettarkiv/veidemann-warc-inspector-image:1.2.0
+      image: ghcr.io/nlnwa/veidemann-warc-inspector-image:1.3.0
       args:
         - "sh"
         - "-c"
@@ -30,4 +30,3 @@ spec:
         - mountPath: "/veidemann/validwarcs"
           name: warcs
           subPath: validwarcs
-


### PR DESCRIPTION
* Update veidemann-dashboard with support for schemaless URL input and schedule calendar
* Update veidemann-util-pod with latest warchaeology and gowarcserver that can index hostnames only